### PR TITLE
Fix music conversion and optimize loops

### DIFF
--- a/audio/Foothills-fixed.pently
+++ b/audio/Foothills-fixed.pently
@@ -1,10 +1,6 @@
 # Audio for NES port of Mega Mountain
-# Copyright 2018 Damian Yerrick
-# License: zlib
-# 
-# Foothills-fixed.o based on output from ft2p had size $8CA
-# or 2250 bytes.  After a few rounds of manual optimization,
-# its size was $694 or 1684 bytes.
+# Copyright 2018 adrian09_01
+# License: MIT
 
 durations stick
 notenames english
@@ -42,6 +38,14 @@ sfx text on noise
   volume 15 15 15 15 15
   pitch 15 14 13 14 15
   timbre 1 1 0 1 0
+
+# Music by Damian Yerrick
+# License: zlib
+# 
+# Foothills-fixed.o based on output from ft2p had size $8CA
+# or 2250 bytes.  After a few rounds of manual optimization
+# to remove repetition that FamiTracker's order table can't
+# easily represent, its size was $694 or 1684 bytes.
 
 song Foothills
   time 12/16

--- a/audio/Foothills-fixed.pently
+++ b/audio/Foothills-fixed.pently
@@ -1,3 +1,11 @@
+# Audio for NES port of Mega Mountain
+# Copyright 2018 Damian Yerrick
+# License: zlib
+# 
+# Foothills-fixed.o based on output from ft2p had size $8CA
+# or 2250 bytes.  After a few rounds of manual optimization,
+# its size was $694 or 1684 bytes.
+
 durations stick
 notenames english
 
@@ -33,8 +41,8 @@ sfx fall on pulse
 sfx text on noise
   volume 15 15 15 15 15
   pitch 15 14 13 14 15
-  timbre 1 1 0 1 0           
-  
+  timbre 1 1 0 1 0
+
 song Foothills
   time 12/16
   scale 16
@@ -58,38 +66,28 @@ song Foothills
     d#''8 g''8 w16 g'16 a#'8 d''16 d#''8 g''16
     c''8 w16 f''4 w8 g#''8 w16
     w8 w16 f''4 w16 d''16 c''8 a#'16 
-  pattern accomp_A4 with ban on pulse1
+  pattern accomp_A4BC with piano on pulse1
     absolute
-    @piano d#''8 w16 r8 d''8 @ban a#'16 d''16 f''16 g#''16 a#''16
-
-  pattern accomp_B1 with pianov02 on pulse1
-    absolute
-    w8 w16 c'8 w16 r8 d#'8 w16 r16
+    d#''8 w16 r8 d''8 @ban a#'16 d''16 f''16 g#''16 a#''16
+    # B
+    w8 w16 @pianov02 c'8 w16 r8 d#'8 w16 r16
     g#'8 r16 g#'8 d#'8 w16 r16 g#'8 r16
     a#'4 w16 @lateban a#'8 w16 w4
     w2 w4 
-  pattern accomp_B2 with pianov02 on pulse1
-    absolute
-    w8 w16 c''8 w16 r8 g#'8 w16 r16
+    w8 w16 @pianov02 c''8 w16 r8 g#'8 w16 r16
     d#'8 r16 d#'8 g#'8 w16 r16 c'8 r16
-    a#8 w16 c#'4 w16 @lateban a#''16 c'''8 w16
+    a#8 w16 c#'4 w16 @ban a#''16 c'''8 w16
     w2 w4
-  pattern accomp_B3 with ban on pulse1
-    absolute
     w8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
     w8 @ban c'''4 c'''8 w16 @triple_ding d#'''8 w16
     @ban a#''8 w16 a#''8 w16 a#''4 w16 @triple_ding d#'''16
     @piano c#''8 d#''8 r16 f''4 r8 w16 
-  pattern accomp_B4 with ban on pulse1
-    absolute
-    r8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
+    w8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
     w8 @ban c'''4 c'''8 w16 @pianov02 d#''8 w16
     d''8 w16 r8 w16 d#''8 w16 r8 f''16
     w4 w16 @ban e''16 f''16 d''16 a#'16 g#'16 f'16 d'16 
-
-  pattern accomp_C with pianov02 on pulse1
-    absolute
-    g'2 w16 a#'8 w16
+    # C
+    @pianov02 g'2 w16 a#'8 w16
     g#'4 w16 a#'4 g#'8 w16
     g'2 w16 g''8 w16
     f''4 w16 g''4 f''8 w16 
@@ -178,25 +176,25 @@ song Foothills
 
   pattern drum_A
     kick8 w16 snare8 w16 kick8 w16 snare8 w16
-    kick8 w16 snare8 kick16 clhat_c_8 kick16 snare8 clhat_c_16 
+    kick8 w16 snare8 kick16 clhat8 kick16 snare8 clhat16 
   pattern drum_fill_0
-    kick8 w16 snare8 kick16 clhat_c_8 kick16 snare16 clhat_c_16 snare16 
+    kick8 w16 snare8 kick16 clhat8 kick16 snare16 clhat16 snare16 
   pattern drum_introend
     kick8 w16 snare8 w16 kick8 w16 snare8 kick4
-      w8 w16 clhat_c_8 w16 clhat_c_8 w16 
+      w8 w16 clhat8 w16 clhat8 w16 
   pattern drum_Aend
     kick8 w16 kick8 snare16 kick8 kick16 snare16 snare16 snare16 
   pattern drum_B
-    kick8 clhat_c_16 clhat_c_8 kick16 snare8 w16 clhat_c_8 snare16
-    kick8 clhat_c_16 kick8 clhat_c_16 snare8 w16 clhat_c_8 w16
-    kick8 clhat_c_16 clhat_c_8 kick16 snare8 w16 clhat_c_8 snare16
-    kick8 clhat_c_16 kick8 clhat_c_16 snare8 clhat_c_16 snare8 w16 
+    kick8 clhat16 clhat8 kick16 snare8 w16 clhat8 snare16
+    kick8 clhat16 kick8 clhat16 snare8 w16 clhat8 w16
+    kick8 clhat16 clhat8 kick16 snare8 w16 clhat8 snare16
+    kick8 clhat16 kick8 clhat16 snare8 clhat16 snare8 w16 
   pattern drum_Bend
-    w4 w8 clhat_c_8 w16 clhat_c_8 w16 
+    w4 w8 clhat8 w16 clhat8 w16 
   pattern drum_C
-    kick8 w16 clhat_c_8 w16 kick8 w16 snare8 w16 
+    kick8 w16 clhat8 w16 kick8 w16 snare8 w16 
   pattern drum_Cend
-    snare4 w8 clhat_c_2 w4 w8 w1 
+    snare4 w8 clhat2 w4 w8 w1 
 
   at 1
   play accomp_intro
@@ -232,28 +230,20 @@ song Foothills
   at 23
   play lead_A2 with pianov02
   at 24
-  play accomp_A4
+  play accomp_A4BC
   play drum_Aend
 
   at 25
-  play accomp_B1
   play lead_B1
   play bass_B
   play drum_B
-  at 29
-  play accomp_B2
-  at 33
-  play accomp_B3
   at 35
   play lead_B2
   play bass_B2C
-  at 37
-  play accomp_B4
   at 40
   play drum_Bend
 
   at 41
-  play accomp_C
   play lead_C
   play drum_C
   at 46
@@ -319,12 +309,12 @@ song Intro_Theme_26_Ending
     f#'8 r4 w8 
 
   pattern drum_A
-    r8 clhat_c_8
+    r8 clhat8
   pattern drum_Aend
     kick8 kick8 
   pattern drum_B
-    kick8 clhat_c_8 clhat_c_8 clhat_c_8
-    kick8 clhat_c_8 snare8 clhat_c_8
+    kick8 clhat8 clhat8 clhat8
+    kick8 clhat8 snare8 clhat8
 
   at 1
   play accomp_A
@@ -401,7 +391,7 @@ song Villain
     d8 g#8 c8 d8 f'8 g#8 c8 d8 d8 g#8 c8 d8 f'8 g#8 c8 d8 
 
   pattern drum_0
-    kick8 clhat_c_8 ohat_c_8 kick8 snare8 clhat_c_8 ohat_c_4 kick8 clhat_c_16 kick16 ohat_c_8 kick8 snare8 clhat_c_8 ohat_c_4 
+    kick8 clhat8 ohat8 kick8 snare8 clhat8 ohat4 kick8 clhat16 kick16 ohat8 kick8 snare8 clhat8 ohat4 
 
   at 1
   play rhy on pulse1
@@ -419,22 +409,22 @@ sfx noise_kicksnare_0 on noise
   volume 11 8 6 4 3 2 1 1 
   pitch 10 0 
 
-drum kick noise_kicksnare_0
 sfx noise_kicksnare_a on noise
   volume 11 8 6 4 3 2 1 1 
   pitch 4 10 
 
-drum snare noise_kicksnare_a
 sfx noise_clhat_c on noise
   volume 5 3 2 1 1 
   timbre | 0 1 
   pitch 12 
 
-drum clhat_c_ noise_clhat_c
 sfx noise_ohat_c on noise
   volume 5 5 4 4 3 3 2 2 2 2 1 1 1 1 
   timbre | 0 1 
   pitch 12 
 
-drum ohat_c_ noise_ohat_c
+drum kick noise_kicksnare_0
+drum snare noise_kicksnare_a
+drum clhat noise_clhat_c
+drum ohat noise_ohat_c
 

--- a/audio/Foothills-fixed.pently
+++ b/audio/Foothills-fixed.pently
@@ -52,46 +52,31 @@ song Foothills
       @lateban a#''8 f''8 a#'16
     w16 pp w4
 
-  pattern accomp_A1 with piano on pulse1
+  pattern accomp_A3 with ban on pulse1
     absolute
-    r4 w16 pp g'8 g#'16 a#'8 d#''8 w16 r16
-    g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16
-    g#'8 w16 r8 w16 c''8 w16 r8 w16
-    d''8 w16 r8 f'4 w16 
-  pattern accomp_A2 with piano on pulse1
-    absolute
-    r4 w16 pp g'8 g#'16 a#'8 d#''8 w16 r16
-    g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16
-    c''8 w16 r8 w16 d#''8 w16 r8 w16
-    g''8 w16 r8 f''4 w16 
-  pattern accomp_A3 with lateban on pulse1
-    absolute
-    r2 w16 mp a#'8
-    d''16 d#''8 g''8 w16 g'16 a#'8 d''16 d#''8 g''16
-    c''8 w16 f''4 w8 g#''8 w16
-    w8 w16 f''4 w16 d''16 c''8 a#'16 
-  pattern accomp_A4 with lateban on pulse1
-    absolute
-    r2 w16 a#'8 d''16
+    w2 w16 ff a#'8 d''16
     d#''8 g''8 w16 g'16 a#'8 d''16 d#''8 g''16
     c''8 w16 f''4 w8 g#''8 w16
+    w8 w16 f''4 w16 d''16 c''8 a#'16 
+  pattern accomp_A4 with ban on pulse1
+    absolute
     @piano d#''8 w16 r8 d''8 @ban a#'16 d''16 f''16 g#''16 a#''16
 
   pattern accomp_B1 with pianov02 on pulse1
     absolute
-    r8 w16 c'8 w16 r8 d#'8 w16 r16
+    w8 w16 c'8 w16 r8 d#'8 w16 r16
     g#'8 r16 g#'8 d#'8 w16 r16 g#'8 r16
     a#'4 w16 @lateban a#'8 w16 w4
     w2 w4 
   pattern accomp_B2 with pianov02 on pulse1
     absolute
-    r8 w16 c''8 w16 r8 g#'8 w16 r16
+    w8 w16 c''8 w16 r8 g#'8 w16 r16
     d#'8 r16 d#'8 g#'8 w16 r16 c'8 r16
     a#8 w16 c#'4 w16 @lateban a#''16 c'''8 w16
     w2 w4
   pattern accomp_B3 with ban on pulse1
     absolute
-    r8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
+    w8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
     w8 @ban c'''4 c'''8 w16 @triple_ding d#'''8 w16
     @ban a#''8 w16 a#''8 w16 a#''4 w16 @triple_ding d#'''16
     @piano c#''8 d#''8 r16 f''4 r8 w16 
@@ -118,7 +103,7 @@ song Foothills
 
   pattern lead_A1 with piano on pulse2
     absolute
-    r8 w16 ff g'8 g#'16 a#'8 d#''8 w16 r16
+    r8 w16 g'8 g#'16 a#'8 d#''8 w16 r16
     g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16
     g#'8 w16 r8 w16 c''8 w16 r8 w16
     d''8 w16 r8 f'4 w8 w16 
@@ -127,27 +112,21 @@ song Foothills
     c''8 w16 r8 w16 d#''8 w16 r8 w16
     g''8 w16 r8 f''4 w8 w16 
 
-  pattern lead_8 with piano on pulse2
+  pattern lead_B1 with piano on pulse2
     absolute
-    r8 w16 g#'8 w16 r8 c''8 w16 r16
+    w8 w16 @piano g#'8 w16 r8 c''8 w16 r16
     d#''8 r16 d#''8 c''8 w16 r16 d#''8 r16
     g''4 w8 @lateban d#''8 g''16 g#''8 a#''16
     w8 @triple_ding d#'''4 d#'''4 w8 
-  pattern lead_9 with piano on pulse2
-    absolute
-    r8 w16 g#''8 w16 r8 d#''8 w16 r16
+    w8 w16 @piano g#''8 w16 r8 d#''8 w16 r16
     c''8 r16 c''8 d#''8 w16 r16 g#'8 r16
     g'8 w16 a#'2 @lateban d'''16
     d#'''8 a#''16 g''8 a#''16 g''8 f''16 d#''8 c''16 
-  pattern lead_6 with piano on pulse2
+  pattern lead_B2 with piano on pulse2
     absolute
-    r8 w16 g#'8 w16 r8 c''8 w16 r16
-    d#''8 r16 d#''8 c''8 w16 r16 d#''8 r16
     g''4 w16 @pianov02 g16 a#8 c#'16 d#'8 g'16
     a#'8 c''8 r16 c#''4 r8 w16 
-  pattern lead_7 with piano on pulse2
-    absolute
-    r8 w16 a'8 w16 r8 c''8 w16 r16
+    w8 w16 @piano a'8 w16 r8 c''8 w16 r16
     d#''8 r16 d#''8 c''8 w16 r16 g''8 w16
     f''8 w16 r8 w16 g''8 w16 r8 g#''16
     w4 w16 @lateban a'16 a#'16 g#'16 f'16 d'16 a#16 g#16 
@@ -235,44 +214,41 @@ song Foothills
   play drum_introend
 
   at 9
-  play accomp_A1
   play lead_A1
   play bass_A
   play drum_A
-  at 13
-  play accomp_A2
+  at 9:1:2
+  play lead_A1 on pulse1
   at 15
   play lead_A2
+  at 15:1:2
+  play lead_A2 on pulse1
   at 16
   play drum_fill_0
   at 17
   play accomp_A3
   play lead_A1 with pianov02
   play drum_A
-  at 21
-  play accomp_A4
   at 23
   play lead_A2 with pianov02
-
   at 24
+  play accomp_A4
   play drum_Aend
 
   at 25
   play accomp_B1
-  play lead_8
+  play lead_B1
   play bass_B
   play drum_B
   at 29
   play accomp_B2
-  play lead_9
   at 33
   play accomp_B3
-  play lead_6
   at 35
+  play lead_B2
   play bass_B2C
   at 37
   play accomp_B4
-  play lead_7
   at 40
   play drum_Bend
 

--- a/audio/Foothills-fixed.pently
+++ b/audio/Foothills-fixed.pently
@@ -40,84 +40,126 @@ song Foothills
   scale 16
   tempo 240
 
-  pattern accomp_0 with ban on pulse1
+  pattern accomp_intro with ban on pulse1
     absolute
     ff g'4 w8 g'4 w8
     g'4 w16 a#4 c'8 w16 
     g'4 w8 g'4 w8
     g'4 w16 c'4 d'8 w16 
-  pattern accomp_2 with ban on pulse1
+  pattern accomp_introend with ban on pulse1
     absolute
     g'4 w8 g'4 w16 f'2
-      @lateban a#''8 f''8 a#'16 
-  pattern accomp_1 with piano on pulse1
-    absolute
-    r4 w16 pp g'8 g#'16 a#'8 d#''8 w16 r16 g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16 g#'8 w16 r8 w16 c''8 w16 r8 w16 d''8 w16 r8 f'4 w16 
-  pattern accomp_3 with piano on pulse1
-    absolute
-    r4 w16 pp g'8 g#'16 a#'8 d#''8 w16 r16 g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16 c''8 w16 r8 w16 d#''8 w16 r8 w16 g''8 w16 r8 f''4 w16 
-  pattern accomp_4 with ban on pulse1
-    absolute
-    r2 w16 a#'8 d''16 d#''8 g''8 w16 @lateban g'16 @ban a#'8 d''16 d#''8 g''16 c''8 w16 f''4 w8 g#''4 w8 f''4 w16 d''16 c''8 a#'16 
-  pattern accomp_5 with ban on pulse1
-    absolute
-    r2 w16 a#'8 d''16 d#''8 g''8 w16 @lateban g'16 @ban a#'8 d''16 d#''8 g''16 c''8 w16 f''4 w8 g#''8 w16 @piano d#''8 w16 r8 d''8 @ban a#'16 d''16 f''16 g#''16 a#''16 
-  pattern accomp_8 with pianov02 on pulse1
-    absolute
-    r8 w16 c'8 w16 r8 d#'8 w16 r16 g#'8 r16 g#'8 d#'8 w16 r16 g#'8 r16 a#'4 w16 @lateban a#'8 w16 w1 
-  pattern accomp_9 with pianov02 on pulse1
-    absolute
-    r8 w16 c''8 w16 r8 g#'8 w16 r16 d#'8 r16 d#'8 g#'8 w16 r16 c'8 r16 a#8 w16 c#'4 w16 @lateban a#''16 c'''2 w4 w8 w16 
-  pattern accomp_6 with ban on pulse1
-    absolute
-    r8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''8 w16 @ban c'''4 c'''8 w16 @triple_ding d#'''8 w16 @ban a#''8 w16 a#''8 w16 a#''4 w16 @triple_ding d#'''16 @piano c#''8 d#''8 r16 f''4 r8 w16 
-  pattern accomp_7 with ban on pulse1
-    absolute
-    r8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''8 w16 @ban c'''4 c'''8 w16 @pianov02 d#''8 w16 d''8 w16 r8 w16 d#''8 w16 r8 f''4 w8 @ban e''16 f''16 d''16 a#'16 g#'16 f'16 d'16 
-  pattern accomp_10 with pianov02 on pulse1
-    absolute
-    g'2 w16 a#'8 w16 g#'4 w16 a#'4 g#'8 w16 g'2 w16 g''8 w16 f''4 w16 g''4 f''8 w16 
-  pattern accomp_11 with pianov02 on pulse1
-    absolute
-    d#''4 w16 c''4 g#'8 w16 f'8 w16 r8 w16 f2 w4 w8 w1 
+      @lateban a#''8 f''8 a#'16
+    w16 pp w4
 
-  pattern lead_0 with lateban on pulse2
+  pattern accomp_A1 with piano on pulse1
     absolute
-    ff a#'4 w8 a#'4 w8 a#'4 w16 c#'4 d#'8 w16 a#'4 w8 a#'4 w8 a#'4 w16 d#'4 f'8 w16 
-  pattern lead_2 with lateban on pulse2
+    r4 w16 pp g'8 g#'16 a#'8 d#''8 w16 r16
+    g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16
+    g#'8 w16 r8 w16 c''8 w16 r8 w16
+    d''8 w16 r8 f'4 w16 
+  pattern accomp_A2 with piano on pulse1
+    absolute
+    r4 w16 pp g'8 g#'16 a#'8 d#''8 w16 r16
+    g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16
+    c''8 w16 r8 w16 d#''8 w16 r8 w16
+    g''8 w16 r8 f''4 w16 
+  pattern accomp_A3 with lateban on pulse1
+    absolute
+    r2 w16 mp a#'8
+    d''16 d#''8 g''8 w16 g'16 a#'8 d''16 d#''8 g''16
+    c''8 w16 f''4 w8 g#''8 w16
+    w8 w16 f''4 w16 d''16 c''8 a#'16 
+  pattern accomp_A4 with lateban on pulse1
+    absolute
+    r2 w16 a#'8 d''16
+    d#''8 g''8 w16 g'16 a#'8 d''16 d#''8 g''16
+    c''8 w16 f''4 w8 g#''8 w16
+    @piano d#''8 w16 r8 d''8 @ban a#'16 d''16 f''16 g#''16 a#''16
+
+  pattern accomp_B1 with pianov02 on pulse1
+    absolute
+    r8 w16 c'8 w16 r8 d#'8 w16 r16
+    g#'8 r16 g#'8 d#'8 w16 r16 g#'8 r16
+    a#'4 w16 @lateban a#'8 w16 w4
+    w2 w4 
+  pattern accomp_B2 with pianov02 on pulse1
+    absolute
+    r8 w16 c''8 w16 r8 g#'8 w16 r16
+    d#'8 r16 d#'8 g#'8 w16 r16 c'8 r16
+    a#8 w16 c#'4 w16 @lateban a#''16 c'''8 w16
+    w2 w4
+  pattern accomp_B3 with ban on pulse1
+    absolute
+    r8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
+    w8 @ban c'''4 c'''8 w16 @triple_ding d#'''8 w16
+    @ban a#''8 w16 a#''8 w16 a#''4 w16 @triple_ding d#'''16
+    @piano c#''8 d#''8 r16 f''4 r8 w16 
+  pattern accomp_B4 with ban on pulse1
+    absolute
+    r8 w16 c'''8 w16 c'''4 w16 @triple_ding d#'''16
+    w8 @ban c'''4 c'''8 w16 @pianov02 d#''8 w16
+    d''8 w16 r8 w16 d#''8 w16 r8 f''16
+    w4 w16 @ban e''16 f''16 d''16 a#'16 g#'16 f'16 d'16 
+
+  pattern accomp_C with pianov02 on pulse1
+    absolute
+    g'2 w16 a#'8 w16
+    g#'4 w16 a#'4 g#'8 w16
+    g'2 w16 g''8 w16
+    f''4 w16 g''4 f''8 w16 
+    d#''4 w16 c''4 g#'8 w16
+    f'8 w16 r8 w16 f2 w4 w8 w1 
+
+  pattern lead_introend with lateban on pulse2
     absolute
     a#'4 w8 a#'4 w16 @ban d''16
     w8 @triple_ding d''''8 w16 d''''8 w16 @lateban g#''8 d''8 
-  pattern lead_1 with piano on pulse2
+
+  pattern lead_A1 with piano on pulse2
     absolute
-    r8 w16 ff g'8 g#'16 a#'8 d#''8 w16 r16 g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16 g#'8 w16 r8 w16 c''8 w16 r8 w16 d''8 w16 r8 f'4 w8 w16 
-  pattern lead_3 with piano on pulse2
+    r8 w16 ff g'8 g#'16 a#'8 d#''8 w16 r16
+    g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16
+    g#'8 w16 r8 w16 c''8 w16 r8 w16
+    d''8 w16 r8 f'4 w8 w16 
+  pattern lead_A2 with piano on pulse2
     absolute
-    r8 w16 ff g'8 g#'16 a#'8 d#''8 w16 r16 g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16 c''8 w16 r8 w16 d#''8 w16 r8 w16 g''8 w16 r8 f''4 w8 w16 
-  pattern lead_4 with pianov02 on pulse2
-    absolute
-    r8 w16 ff g'8 g#'16 a#'8 d#''8 w16 r16 g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16 g#'8 w16 r8 w16 c''8 w16 r8 w16 d''8 w16 r8 f'4 w8 w16 
-  pattern lead_5 with pianov02 on pulse2
-    absolute
-    r8 w16 ff g'8 g#'16 a#'8 d#''8 w16 r16 g'8 g#'16 a#'8 c''8 r16 c''16 a#'8 r16 c''8 w16 r8 w16 d#''8 w16 r8 w16 g''8 w16 r8 f''4 w8 w16 
+    c''8 w16 r8 w16 d#''8 w16 r8 w16
+    g''8 w16 r8 f''4 w8 w16 
+
   pattern lead_8 with piano on pulse2
     absolute
-    r8 w16 g#'8 w16 r8 c''8 w16 r16 d#''8 r16 d#''8 c''8 w16 r16 d#''8 r16 g''4 w8 @lateban d#''8 g''16 g#''8 a#''8 w16 @triple_ding d#'''4 d#'''4 w8 
+    r8 w16 g#'8 w16 r8 c''8 w16 r16
+    d#''8 r16 d#''8 c''8 w16 r16 d#''8 r16
+    g''4 w8 @lateban d#''8 g''16 g#''8 a#''16
+    w8 @triple_ding d#'''4 d#'''4 w8 
   pattern lead_9 with piano on pulse2
     absolute
-    r8 w16 g#''8 w16 r8 d#''8 w16 r16 c''8 r16 c''8 d#''8 w16 r16 g#'8 r16 g'8 w16 a#'2 @lateban d'''16 d#'''8 a#''16 g''8 a#''16 g''8 f''16 d#''8 c''16 
+    r8 w16 g#''8 w16 r8 d#''8 w16 r16
+    c''8 r16 c''8 d#''8 w16 r16 g#'8 r16
+    g'8 w16 a#'2 @lateban d'''16
+    d#'''8 a#''16 g''8 a#''16 g''8 f''16 d#''8 c''16 
   pattern lead_6 with piano on pulse2
     absolute
-    r8 w16 g#'8 w16 r8 c''8 w16 r16 d#''8 r16 d#''8 c''8 w16 r16 d#''8 r16 g''4 w16 @pianov02 g16 a#8 c#'16 d#'8 g'16 a#'8 c''8 r16 c#''4 r8 w16 
+    r8 w16 g#'8 w16 r8 c''8 w16 r16
+    d#''8 r16 d#''8 c''8 w16 r16 d#''8 r16
+    g''4 w16 @pianov02 g16 a#8 c#'16 d#'8 g'16
+    a#'8 c''8 r16 c#''4 r8 w16 
   pattern lead_7 with piano on pulse2
     absolute
-    r8 w16 a'8 w16 r8 c''8 w16 r16 d#''8 r16 d#''8 c''8 w16 r16 g''8 w16 f''8 w16 r8 w16 g''8 w16 r8 g#''4 w8 @lateban a'16 a#'16 g#'16 f'16 d'16 a#16 g#16 
-  pattern lead_10 with piano on pulse2
+    r8 w16 a'8 w16 r8 c''8 w16 r16
+    d#''8 r16 d#''8 c''8 w16 r16 g''8 w16
+    f''8 w16 r8 w16 g''8 w16 r8 g#''16
+    w4 w16 @lateban a'16 a#'16 g#'16 f'16 d'16 a#16 g#16 
+
+  pattern lead_C with piano on pulse2
     absolute
-    a#'2 w16 g''8 w16 f''4 w16 g''4 f''8 w16 d#''2 w16 d#'''8 w16 c#'''4 w16 d#'''4 c#'''8 w16 
-  pattern lead_11 with piano on pulse2
-    absolute
-    c'''4 w16 d#'''4 c'''8 w16 d'''8 w16 r8 w16 d'2 w4 w8 w1 
+    a#'2 w16 g''8
+    w16 f''4 w16 g''4 f''8 w16
+    d#''2 w16 d#'''8 w16
+    c#'''4 w16 d#'''4 c#'''8 w16 
+    c'''4 w16 d#'''4 c'''8 w16
+    d'''8 w16 r8 w16 d'2 w4 w8 w1 
 
   pattern bass_0 with _11fbass on triangle
     absolute
@@ -178,8 +220,8 @@ song Foothills
     snare4 w8 clhat_c_2 w4 w8 w1 
 
   at 1
-  play accomp_0
-  play accomp_0 on pulse2 with lateban up 3
+  play accomp_intro
+  play accomp_intro on pulse2 with lateban up 3
   play bass_0
   play drum_A
   at 4
@@ -187,57 +229,57 @@ song Foothills
   at 5
   play drum_A
   at 7
-  play accomp_2
-  play lead_2
+  play accomp_introend
+  play lead_introend
   play bass_2
   play drum_introend
 
   at 9
-  play accomp_1
-  play lead_1
+  play accomp_A1
+  play lead_A1
   play bass_A
   play drum_A
   at 13
-  play accomp_3
-  play lead_3
+  play accomp_A2
+  at 15
+  play lead_A2
   at 16
   play drum_fill_0
   at 17
-  play accomp_4
-  play lead_4
+  play accomp_A3
+  play lead_A1 with pianov02
   play drum_A
   at 21
-  play accomp_5
-  play lead_5
+  play accomp_A4
+  at 23
+  play lead_A2 with pianov02
+
   at 24
   play drum_Aend
 
   at 25
-  play accomp_8
+  play accomp_B1
   play lead_8
   play bass_B
   play drum_B
   at 29
-  play accomp_9
+  play accomp_B2
   play lead_9
   at 33
-  play accomp_6
+  play accomp_B3
   play lead_6
   at 35
   play bass_B2C
   at 37
-  play accomp_7
+  play accomp_B4
   play lead_7
   at 40
   play drum_Bend
 
   at 41
-  play accomp_10
-  play lead_10
+  play accomp_C
+  play lead_C
   play drum_C
-  at 45
-  play accomp_11
-  play lead_11
   at 46
   play drum_Cend
   at 47

--- a/obj/nes/index.txt
+++ b/obj/nes/index.txt
@@ -1,0 +1,1 @@
+This file forces this directory's creation


### PR DESCRIPTION
The version of [ft2pently](https://github.com/NovaSquirrel/ft2pently) used to convert Foothills.ftm had defects. @NovaSquirrel fixed them in these commits:
    
* [fe14361ac9](https://github.com/NovaSquirrel/ft2pently/commit/fe14361ac92b405be55930cb0e0e2c026eda035e) (allow w at start of pattern)
* [888417b43e](https://github.com/NovaSquirrel/ft2pently/commit/888417b43e0a2b48d7b76ac32126810c0de210fb) (allow leading negative on arp sequence)
* [e4f201f6a9](https://github.com/NovaSquirrel/ft2pently/commit/e4f201f6a9b4179a77bc57a349912b5687758794) (round correctly in auto decay)
* [b33c829c81](https://github.com/NovaSquirrel/ft2pently/commit/b33c829c817ed518e27513ce03b091f7242fb004) (don't decay in sound effects)
    
But the version of ft2pently used to convert Foothills.ftm was from before these commits.  So I fixed all problems manually, as well as a problem that I didn't notice at first related to a volume command.

And while I was at it, I made some maintainability improvements:

* Make pattern and drum names sane
* Separate measures within a pattern onto separate lines of text
* Optimize loops in the data, saving over 500 bytes of `RODATA`